### PR TITLE
feat: move into file based system

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A lightweight Python package for managing and versioning LLM prompt templates.
 - Template versioning
 - Tag-based organization
 - Jinja2 template syntax
+- **Variable highlighting** in Markdown exports for better visibility
 - Package integration utilities
 
 ## Installation
@@ -28,9 +29,12 @@ store = PromptStore("./prompts")
 
 # Add a prompt template
 prompt = store.add(
+    name="example",
     content="Write a {{language}} function that {{task}}",
+    namespace="project1",
     description="Code generation prompt",
-    tags=["coding", "generation"]
+    tags=["coding", "generation"],
+    subset="subproject1"
 )
 
 # Use the prompt

--- a/README.md
+++ b/README.md
@@ -44,6 +44,42 @@ filled = prompt.fill({
 })
 ```
 
+This automatically generates a markdown representation like this:
+
+```markdown
+---
+uuid: 77a6b015-efea-436e-8636-6ae06c438ad8
+name: example
+namespace: project1
+description: Code generation prompt
+version: 1
+tags:
+- coding
+- generation
+variables:
+- language
+- task
+subset: subproject1
+created_at: '2025-11-12T11:17:24.128334+00:00'
+updated_at: '2025-11-12T11:17:24.128334+00:00'
+---
+
+Write a **`{{language}}`** function that **`{{task}}`**
+```
+
+This makes it easy to identify which parts of the prompt are variables when viewing the markdown files.
+
+## Prompt Usage
+
+```python
+# Fill a prompt template
+prompt = store.get("namespace/name@subset")
+result = prompt.fill({
+    "language": "Python",
+    "task": "sorts a list in ascending order"
+})
+```
+
 ## Documentation
 
 Full documentation is available at [lamalab-org.github.io/promptstore](https://lamalab-org.github.io/promptstore/).

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -54,6 +54,58 @@ result = prompt.fill({
     "language": "Python",
     "task": "sorts a list in ascending order"
 })
+
+# Get list of variables in a prompt
+variables = prompt.get_variables()
+print(f"Required variables: {variables}")  # ['language', 'task']
+```
+
+### Exporting and Importing Prompts
+
+Prompts can be exported to Markdown format with YAML frontmatter. When exported, template variables are automatically highlighted for better visibility:
+
+```python
+# Export prompt to markdown
+markdown = prompt.to_markdown()
+print(markdown)
+```
+
+Example output:
+
+```markdown
+---
+uuid: 6172841b-e296-4d4b-bb32-7b8a074ab36e
+name: code-generator
+namespace: default
+description: Code generation prompt
+version: 1
+tags:
+- coding
+- generation
+variables:
+- language
+- task
+---
+
+Write a **`{{language}}`** function that **`{{task}}`**
+```
+
+Variables are highlighted as **`{{variable}}`** (bold code blocks) in the markdown output, making them visually distinct and easier to identify.
+
+You can also load prompts from markdown:
+
+```python
+from promptstore import Prompt
+
+# Load from markdown file
+with open("prompt.md", "r") as f:
+    markdown_content = f.read()
+
+prompt = Prompt.from_markdown(markdown_content)
+
+# The highlighting is automatically removed when loading
+# and the prompt works exactly as before
+result = prompt.fill({"language": "Python", "task": "sorts a list"})
 ```
 
 Similarly, you can use prompts from an online source:

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -30,11 +30,42 @@ prompt = store.add(
     description="Code generation prompt",
     tags=["coding", "generation"]
 )
+
+# Add to a specific namespace and subset
+prompt = store.add(
+    name="example",
+    content="This is a prompt for {{purpose}}",
+    namespace="project1",
+    description="Code generation prompt",
+    tags=["coding", "generation"],
+    subset="subproject1"
+)
 ```
+
+### Prompt management
+
+The prompts will be stored in the following structure:
+
+```prompts/
+└── namespace/
+    └── name/
+        └── subset/
+            └── subproject1.md
+```
+
+If no namespace is provided, the prompt will be stored in the `default` namespace. If no subset is provided, the prompt will be stored directly under the prompt name.
+
+On top of the markdown file, a YAML front matter is included with metadata about the prompt, including its UUID, version, tags, and variables.
 
 ### Retrieving Prompts
 
 ```python
+# Get by name and namespace
+prompt = store.get("namespace/name@subset")
+
+# Get an specific version
+old_version = store.get("namespace/name@subset", version=1)
+
 # Get by UUID
 prompt = store.get("prompt-uuid")
 
@@ -58,65 +89,4 @@ result = prompt.fill({
 # Get list of variables in a prompt
 variables = prompt.get_variables()
 print(f"Required variables: {variables}")  # ['language', 'task']
-```
-
-### Exporting and Importing Prompts
-
-Prompts can be exported to Markdown format with YAML frontmatter. When exported, template variables are automatically highlighted for better visibility:
-
-```python
-# Export prompt to markdown
-markdown = prompt.to_markdown()
-print(markdown)
-```
-
-Example output:
-
-```markdown
----
-uuid: 6172841b-e296-4d4b-bb32-7b8a074ab36e
-name: code-generator
-namespace: default
-description: Code generation prompt
-version: 1
-tags:
-- coding
-- generation
-variables:
-- language
-- task
----
-
-Write a **`{{language}}`** function that **`{{task}}`**
-```
-
-Variables are highlighted as **`{{variable}}`** (bold code blocks) in the markdown output, making them visually distinct and easier to identify.
-
-You can also load prompts from markdown:
-
-```python
-from promptstore import Prompt
-
-# Load from markdown file
-with open("prompt.md", "r") as f:
-    markdown_content = f.read()
-
-prompt = Prompt.from_markdown(markdown_content)
-
-# The highlighting is automatically removed when loading
-# and the prompt works exactly as before
-result = prompt.fill({"language": "Python", "task": "sorts a list"})
-```
-
-Similarly, you can use prompts from an online source:
-
-```python
-url = "https://raw.githubusercontent.com/awesome-org/prompt-collections/main/prompts.json"
-# Using a sample prompt collection hosted on GitHub.
-# Fill a prompt template
-prompt = store.get_online("prompt-uuid", url)
-result = prompt.fill({
-    "language": "Python",
-    "task": "sorts a list in ascending order"
-})
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,19 +15,41 @@ Create a store and add some prompts:
 ```python
 from promptstore import PromptStore
 
-# Create a new store
+# Create a store
 store = PromptStore("./prompts")
 
-# Add a prompt
+# Add a prompt template
 prompt = store.add(
-    content="Explain {{concept}} in simple terms",
-    description="Simplification prompt",
-    tags=["explanation", "simplification"]
+    name="example",
+    content="Write a {{language}} function that {{task}}",
+    namespace="project1",
+    description="Code generation prompt",
+    tags=["coding", "generation"],
+    subset="subproject1"
 )
 
 # Use the prompt
-explanation = prompt.fill({"concept": "quantum computing"})
+filled = prompt.fill({
+    "language": "Python",
+    "task": "sorts a list in reverse order"
+})
+
+# Export to markdown (variables will be highlighted)
+markdown = prompt.to_markdown()
+print(markdown)
+# Output shows: Explain **`{{concept}}`** in simple terms
 ```
+
+## Variable Highlighting
+
+When you export prompts to markdown, template variables are automatically highlighted with bold code formatting (**`{{variable}}`**), making them stand out visually. This is especially useful when:
+
+- Reviewing prompts in markdown viewers or editors
+- Sharing prompts with team members
+- Documenting your prompt templates
+- Identifying which parts of the prompt need to be filled
+
+The highlighting is automatically removed when loading prompts from markdown, so your templates work seamlessly.
 
 ## Next Steps
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,7 +37,7 @@ filled = prompt.fill({
 # Export to markdown (variables will be highlighted)
 markdown = prompt.to_markdown()
 print(markdown)
-# Output shows: Explain **`{{concept}}`** in simple terms
+# Output shows the prompt with **`{{language}}`** and **`{{task}}`** highlighted
 ```
 
 ## Variable Highlighting

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,7 +42,7 @@ print(markdown)
 
 ## Variable Highlighting
 
-When you export prompts to markdown, template variables are automatically highlighted with bold code formatting (**`{{variable}}`**), making them stand out visually. This is especially useful when:
+When the prompts are stored, they are saved in markdown format where template variables are automatically highlighted with bold code formatting (**`{{variable}}`**), making them stand out visually. This is especially useful when:
 
 - Reviewing prompts in markdown viewers or editors
 - Sharing prompts with team members
@@ -50,6 +50,25 @@ When you export prompts to markdown, template variables are automatically highli
 - Identifying which parts of the prompt need to be filled
 
 The highlighting is automatically removed when loading prompts from markdown, so your templates work seamlessly.
+
+## Using Prompts
+
+PromptStore provides a simple Hugging Face-like identifier to manage and use prompts. For that simply use the `get` method indicating the prompt by its name, namespace, and subset:
+
+```python
+# Add a prompt template
+prompt = store.get("namespace/name@subset")
+```
+
+Old way to get and use prompts is by checking the UUID:
+
+```python
+# Fill a prompt template
+prompt = store.get("prompt-uuid")
+result = prompt.fill({
+    "language": "Python",
+    "task": "sorts a list in ascending order"
+})
 
 ## Next Steps
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ A lightweight Python package for managing and versioning LLM prompt templates.
 - Template versioning
 - Tag-based organization
 - Jinja2 template support
+- **Variable highlighting** in Markdown exports
 - Package integration utilities
 - Easy to extend and customize
 
@@ -32,6 +33,30 @@ filled = prompt.fill({
     "task": "sorts a list in reverse order"
 })
 ```
+
+This automatically generates a markdown representation like this:
+
+```markdown
+---
+uuid: 77a6b015-efea-436e-8636-6ae06c438ad8
+name: example
+namespace: project1
+description: Code generation prompt
+version: 1
+tags:
+- coding
+- generation
+variables:
+- language
+- task
+subset: subproject1
+created_at: '2025-11-12T11:17:24.128334+00:00'
+updated_at: '2025-11-12T11:17:24.128334+00:00'
+---
+
+Write a **`{{language}}`** function that **`{{task}}`**
+
+This makes it easy to identify which parts of the prompt are variables when viewing the markdown files.
 
 ## Why PromptStore?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python",
 ]
-dependencies = ["jinja2>=3.0.0", "pystow>=0.7.0"]
+dependencies = ["jinja2>=3.0.0", "pystow>=0.7.0", "loguru"]
 dynamic = ["version"]
 license = { file = "LICENSE" }
 

--- a/src/promptstore/prompt.py
+++ b/src/promptstore/prompt.py
@@ -35,7 +35,7 @@ class Prompt:
         try:
             self._template = Template(content)
         except Exception as e:
-            raise ValueError(f"Invalid Jinja2 template: {e}")
+            raise ValueError(f"Invalid Jinja2 template: {e}") from e
         self.variables = self._extract_variables(content)
 
     @property

--- a/src/promptstore/prompt.py
+++ b/src/promptstore/prompt.py
@@ -1,26 +1,50 @@
+import re
+import uuid as uuid_module
 from typing import List, Optional
 
+import yaml
 from jinja2 import Environment, Template, meta
 
 
 class Prompt:
     def __init__(
         self,
-        uuid: str,
         content: str,
         version: int,
+        name: Optional[str] = None,
+        namespace: Optional[str] = None,
         description: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        subset: Optional[str] = None,
         timestamp: Optional[str] = None,
+        uuid: Optional[str] = None,
+        created_at: Optional[str] = None,
+        updated_at: Optional[str] = None,
     ):
-        self.uuid = uuid
+        self.uuid = uuid or str(uuid_module.uuid4())
+        self.name = name
+        self.namespace = namespace
         self.content = content
         self.description = description
         self.version = version
         self.tags = tags or []
+        self.subset = subset
         self.timestamp = timestamp
+        self.created_at = created_at
+        self.updated_at = updated_at
         self._template = Template(content)
         self.variables = self._extract_variables(content)
+
+    @property
+    def identifier(self) -> str:
+        """Get HuggingFace-style identifier."""
+        if not self.namespace or not self.name:
+            return self.uuid
+
+        base = f"{self.namespace}/{self.name}"
+        if self.subset:
+            base += f"@{self.subset}"
+        return base
 
     def fill(self, variables: dict) -> str:
         """Fill the prompt template with provided variables."""
@@ -36,3 +60,87 @@ class Prompt:
     def get_variables(self) -> List[str]:
         """Return the list of variable names in the template."""
         return self.variables
+
+    def _highlight_variables(self, content: str) -> str:
+        """Highlight Jinja2 variables in markdown format.
+
+        Converts {{variable}} to **`{{variable}}`** for visual emphasis.
+        """
+        # Match {{variable}} patterns and wrap them in **`...`**
+        pattern = r'(\{\{[^}]+\}\})'
+        highlighted = re.sub(pattern, r'**`\1`**', content)
+        return highlighted
+
+    def _unhighlight_variables(self, content: str) -> str:
+        """Remove markdown highlighting from Jinja2 variables.
+
+        Converts **`{{variable}}`** back to {{variable}}.
+        """
+        # Remove **`...`** wrapping from {{variable}} patterns
+        pattern = r'\*\*`(\{\{[^}]+\}\})`\*\*'
+        unhighlighted = re.sub(pattern, r'\1', content)
+        return unhighlighted
+
+    def to_markdown(self) -> str:
+        """Export prompt as Markdown with YAML frontmatter."""
+        frontmatter = {
+            "uuid": self.uuid,
+            "name": self.name,
+            "namespace": self.namespace,
+            "description": self.description,
+            "version": self.version,
+            "tags": self.tags,
+            "variables": self.variables,
+        }
+
+        if self.subset:
+            frontmatter["subset"] = self.subset
+        if self.created_at:
+            frontmatter["created_at"] = self.created_at
+        if self.updated_at:
+            frontmatter["updated_at"] = self.updated_at
+
+        # Remove None values
+        frontmatter = {k: v for k, v in frontmatter.items() if v is not None}
+
+        yaml_str = yaml.dump(
+            frontmatter, default_flow_style=False, sort_keys=False
+        )
+
+        # Highlight variables in the content with bold code formatting
+        highlighted_content = self._highlight_variables(self.content)
+
+        return f"---\n{yaml_str}---\n\n{highlighted_content}"
+
+    @classmethod
+    def from_markdown(cls, markdown_content: str) -> "Prompt":
+        """Create prompt from Markdown with YAML frontmatter."""
+        if not markdown_content.startswith("---"):
+            raise ValueError(
+                "Markdown content must start with YAML frontmatter"
+            )
+
+        parts = markdown_content.split("---", 2)
+        if len(parts) < 3:
+            raise ValueError("Invalid frontmatter format")
+
+        frontmatter = yaml.safe_load(parts[1])
+        content = parts[2].strip()
+
+        # Create a temporary instance to access _unhighlight_variables
+        # (we need this because it's an instance method)
+        temp_instance = cls.__new__(cls)
+        content = temp_instance._unhighlight_variables(content)
+
+        return cls(
+            uuid=frontmatter.get("uuid"),
+            name=frontmatter.get("name"),
+            namespace=frontmatter.get("namespace"),
+            content=content,
+            description=frontmatter.get("description"),
+            version=frontmatter.get("version", 1),
+            tags=frontmatter.get("tags", []),
+            subset=frontmatter.get("subset"),
+            created_at=frontmatter.get("created_at"),
+            updated_at=frontmatter.get("updated_at"),
+        )

--- a/src/promptstore/prompt.py
+++ b/src/promptstore/prompt.py
@@ -66,14 +66,14 @@ class Prompt:
 
     def _highlight_variables(self, content: str) -> str:
         """Highlight Jinja2 variables in markdown format."""
-        pattern = r'(\{\{[^}]+\}\})'
-        return re.sub(pattern, r'**`\1`**', content)
+        pattern = r"(\{\{[^}]+\}\})"
+        return re.sub(pattern, r"**`\1`**", content)
 
     @staticmethod
     def _unhighlight_variables(content: str) -> str:
         """Remove markdown highlighting from Jinja2 variables."""
-        pattern = r'\*\*`(\{\{[^}]+\}\})`\*\*'
-        return re.sub(pattern, r'\1', content)
+        pattern = r"\*\*`(\{\{[^}]+\}\})`\*\*"
+        return re.sub(pattern, r"\1", content)
 
     def to_markdown(self) -> str:
         """Export prompt as Markdown with YAML frontmatter."""
@@ -97,9 +97,7 @@ class Prompt:
         # Remove None values
         frontmatter = {k: v for k, v in frontmatter.items() if v is not None}
 
-        yaml_str = yaml.dump(
-            frontmatter, default_flow_style=False, sort_keys=False
-        )
+        yaml_str = yaml.dump(frontmatter, default_flow_style=False, sort_keys=False)
 
         highlighted_content = self._highlight_variables(self.content)
 
@@ -109,9 +107,7 @@ class Prompt:
     def from_markdown(cls, markdown_content: str) -> "Prompt":
         """Create prompt from Markdown with YAML frontmatter."""
         if not markdown_content.startswith("---"):
-            raise ValueError(
-                "Markdown content must start with YAML frontmatter"
-            )
+            raise ValueError("Markdown content must start with YAML frontmatter")
 
         parts = markdown_content.split("---", 2)
         if len(parts) < 3:

--- a/src/promptstore/prompt.py
+++ b/src/promptstore/prompt.py
@@ -32,7 +32,10 @@ class Prompt:
         self.timestamp = timestamp
         self.created_at = created_at
         self.updated_at = updated_at
-        self._template = Template(content)
+        try:
+            self._template = Template(content)
+        except Exception as e:
+            raise ValueError(f"Invalid Jinja2 template: {e}")
         self.variables = self._extract_variables(content)
 
     @property
@@ -62,24 +65,15 @@ class Prompt:
         return self.variables
 
     def _highlight_variables(self, content: str) -> str:
-        """Highlight Jinja2 variables in markdown format.
-
-        Converts {{variable}} to **`{{variable}}`** for visual emphasis.
-        """
-        # Match {{variable}} patterns and wrap them in **`...`**
+        """Highlight Jinja2 variables in markdown format."""
         pattern = r'(\{\{[^}]+\}\})'
-        highlighted = re.sub(pattern, r'**`\1`**', content)
-        return highlighted
+        return re.sub(pattern, r'**`\1`**', content)
 
-    def _unhighlight_variables(self, content: str) -> str:
-        """Remove markdown highlighting from Jinja2 variables.
-
-        Converts **`{{variable}}`** back to {{variable}}.
-        """
-        # Remove **`...`** wrapping from {{variable}} patterns
+    @staticmethod
+    def _unhighlight_variables(content: str) -> str:
+        """Remove markdown highlighting from Jinja2 variables."""
         pattern = r'\*\*`(\{\{[^}]+\}\})`\*\*'
-        unhighlighted = re.sub(pattern, r'\1', content)
-        return unhighlighted
+        return re.sub(pattern, r'\1', content)
 
     def to_markdown(self) -> str:
         """Export prompt as Markdown with YAML frontmatter."""
@@ -107,7 +101,6 @@ class Prompt:
             frontmatter, default_flow_style=False, sort_keys=False
         )
 
-        # Highlight variables in the content with bold code formatting
         highlighted_content = self._highlight_variables(self.content)
 
         return f"---\n{yaml_str}---\n\n{highlighted_content}"
@@ -129,10 +122,7 @@ class Prompt:
             raise ValueError("Empty frontmatter")
         content = parts[2].strip()
 
-        # Create a temporary instance to access _unhighlight_variables
-        # (we need this because it's an instance method)
-        temp_instance = cls.__new__(cls)
-        content = temp_instance._unhighlight_variables(content)
+        content = cls._unhighlight_variables(content)
 
         return cls(
             uuid=frontmatter.get("uuid"),

--- a/src/promptstore/prompt.py
+++ b/src/promptstore/prompt.py
@@ -125,6 +125,8 @@ class Prompt:
             raise ValueError("Invalid frontmatter format")
 
         frontmatter = yaml.safe_load(parts[1])
+        if frontmatter is None:
+            raise ValueError("Empty frontmatter")
         content = parts[2].strip()
 
         # Create a temporary instance to access _unhighlight_variables

--- a/src/promptstore/store.py
+++ b/src/promptstore/store.py
@@ -76,35 +76,20 @@ class PromptStore:
         """
         # Check if it's a UUID
         if self._is_uuid(identifier):
-            return {
-                "uuid": identifier,
-                "namespace": None,
-                "name": None,
-                "subset": None
-            }
+            return {"uuid": identifier, "namespace": None, "name": None, "subset": None}
 
         # Parse namespace/name[@subset]
-        pattern = r'^([^/]+)/([^@]+)(?:@(.+))?$'
+        pattern = r"^([^/]+)/([^@]+)(?:@(.+))?$"
         match = re.match(pattern, identifier)
 
         if not match:
             # If it doesn't match the pattern and is not a UUID,
             # treat it as a potential UUID for backward compatibility
-            return {
-                "uuid": identifier,
-                "namespace": None,
-                "name": None,
-                "subset": None
-            }
+            return {"uuid": identifier, "namespace": None, "name": None, "subset": None}
 
         namespace, name, subset = match.groups()
 
-        return {
-            "uuid": None,
-            "namespace": namespace,
-            "name": name,
-            "subset": subset
-        }
+        return {"uuid": None, "namespace": namespace, "name": name, "subset": subset}
 
     def _is_uuid(self, value: str) -> bool:
         """Check if a string is a valid UUID."""
@@ -119,7 +104,7 @@ class PromptStore:
         namespace: str,
         name: str,
         subset: Optional[str] = None,
-        version: Optional[int] = None
+        version: Optional[int] = None,
     ) -> Path:
         """Get the file path for a prompt.
 
@@ -207,7 +192,7 @@ class PromptStore:
             index[uuid_val] = {
                 "namespace": namespace,
                 "name": name,
-                "path": str(file_path.relative_to(store.location))
+                "path": str(file_path.relative_to(store.location)),
             }
             store._save_index(index)
 
@@ -301,7 +286,7 @@ class PromptStore:
             "namespace": namespace,
             "name": name,
             "subset": subset,
-            "path": str(file_path.relative_to(self.location))
+            "path": str(file_path.relative_to(self.location)),
         }
         self._save_index(index)
 
@@ -319,7 +304,7 @@ class PromptStore:
         self,
         identifier: str,
         version: Optional[int] = None,
-        subset: Optional[str] = None
+        subset: Optional[str] = None,
     ) -> Prompt:
         """Retrieve a prompt by its identifier or UUID.
 
@@ -338,7 +323,7 @@ class PromptStore:
             warnings.warn(
                 "UUID-based lookup is deprecated. Use 'namespace/name' format.",
                 DeprecationWarning,
-                stacklevel=2
+                stacklevel=2,
             )
             return self._get_by_uuid(parsed["uuid"], version)
 

--- a/src/promptstore/store.py
+++ b/src/promptstore/store.py
@@ -4,12 +4,13 @@ import uuid
 import warnings
 from datetime import datetime, timezone
 from pathlib import Path
+from loguru import logger
 from typing import Dict, Iterator, List, Optional, Union
 
 import pystow
 
-from .exceptions import PromptNotFoundError, ReadOnlyStoreError
-from .prompt import Prompt
+from promptstore.exceptions import PromptNotFoundError, ReadOnlyStoreError
+from promptstore.prompt import Prompt
 
 
 class PromptStore:
@@ -89,8 +90,6 @@ class PromptStore:
         if not match:
             # If it doesn't match the pattern and is not a UUID,
             # treat it as a potential UUID for backward compatibility
-            # This handles cases like "nonexistent-uuid" which might be
-            # a malformed UUID that we still want to look up
             return {
                 "uuid": identifier,
                 "namespace": None,
@@ -258,7 +257,7 @@ class PromptStore:
 
         Args:
             content: The content of the prompt
-            name: Name of the prompt (required for new system)
+            name: Name of the prompt (optional, auto-generated if not provided)
             namespace: Namespace/organization (defaults to 'default')
             description: A description of the prompt
             tags: A list of tags for the prompt
@@ -462,7 +461,8 @@ class PromptStore:
             try:
                 file_path = self.location / entry["path"]
                 yield self._read_prompt_file(file_path)
-            except Exception:
+            except Exception as e:
+                logger.warning(f"Failed to read prompt at {file_path}: {e}")
                 # Skip prompts that can't be read
                 continue
 

--- a/src/promptstore/store.py
+++ b/src/promptstore/store.py
@@ -68,10 +68,10 @@ class PromptStore:
     def _parse_identifier(self, identifier: str) -> Dict[str, Optional[str]]:
         """Parse HuggingFace-style identifier.
 
-        Format: namespace/name[@subset][@version]
+        Format: namespace/name[@subset]
 
         Returns:
-            Dict with keys: namespace, name, subset, version
+            Dict with keys: namespace, name, subset
         """
         # Check if it's a UUID
         if self._is_uuid(identifier):
@@ -79,12 +79,11 @@ class PromptStore:
                 "uuid": identifier,
                 "namespace": None,
                 "name": None,
-                "subset": None,
-                "version": None
+                "subset": None
             }
 
-        # Parse namespace/name[@subset][@version]
-        pattern = r'^([^/]+)/([^@]+)(?:@([^@]+))?(?:@v?(\d+))?$'
+        # Parse namespace/name[@subset]
+        pattern = r'^([^/]+)/([^@]+)(?:@(.+))?$'
         match = re.match(pattern, identifier)
 
         if not match:
@@ -96,27 +95,16 @@ class PromptStore:
                 "uuid": identifier,
                 "namespace": None,
                 "name": None,
-                "subset": None,
-                "version": None
+                "subset": None
             }
 
-        namespace, name, subset_or_version, version = match.groups()
-
-        # Determine if the third group is a subset or version
-        subset = None
-        if subset_or_version:
-            if subset_or_version.startswith('v') or subset_or_version.isdigit():
-                version = subset_or_version.lstrip('v')
-                subset = None
-            else:
-                subset = subset_or_version
+        namespace, name, subset = match.groups()
 
         return {
             "uuid": None,
             "namespace": namespace,
             "name": name,
-            "subset": subset,
-            "version": int(version) if version else None
+            "subset": subset
         }
 
     def _is_uuid(self, value: str) -> bool:
@@ -337,9 +325,9 @@ class PromptStore:
         """Retrieve a prompt by its identifier or UUID.
 
         Args:
-            identifier: HuggingFace-style identifier or UUID
+            identifier: HuggingFace-style identifier (namespace/name[@subset]) or UUID
             version: The version of the prompt to retrieve
-            subset: The subset of the prompt to retrieve
+            subset: The subset of the prompt to retrieve (overrides identifier)
 
         Returns:
             Prompt: The prompt object
@@ -359,7 +347,6 @@ class PromptStore:
         namespace = parsed["namespace"]
         name = parsed["name"]
         subset = subset or parsed["subset"]
-        version = version or parsed["version"]
 
         # Get the file path and read the prompt
         file_path = self._get_prompt_path(namespace, name, subset, version)

--- a/src/promptstore/store.py
+++ b/src/promptstore/store.py
@@ -1,6 +1,8 @@
 import json
+import re
 import uuid
-from datetime import datetime
+import warnings
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Union
 
@@ -20,15 +22,20 @@ class PromptStore:
         """
         self.location = Path(location)
         self.readonly = readonly
-        self.index_path = self.location / "index.json"
+        self.promptstore_dir = self.location / ".promptstore"
+        self.index_path = self.promptstore_dir / "index.json"
+        self.aliases_path = self.promptstore_dir / "aliases.json"
         self._init_storage()
 
     def _init_storage(self):
         """Initialize the storage directory and index."""
         self.location.mkdir(parents=True, exist_ok=True)
+        self.promptstore_dir.mkdir(exist_ok=True)
 
         if not self.index_path.exists() and not self.readonly:
             self._save_index({})
+        if not self.aliases_path.exists() and not self.readonly:
+            self._save_aliases({})
 
     def _load_index(self) -> Dict:
         """Load the prompt index."""
@@ -44,12 +51,137 @@ class PromptStore:
         with open(self.index_path, "w", encoding="utf-8") as f:
             json.dump(index, f, indent=2, ensure_ascii=False)
 
+    def _load_aliases(self) -> Dict:
+        """Load the aliases mapping."""
+        if not self.aliases_path.exists():
+            return {}
+        with open(self.aliases_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def _save_aliases(self, aliases: Dict):
+        """Save the aliases mapping."""
+        if self.readonly:
+            raise ReadOnlyStoreError("Cannot modify a read-only prompt store")
+        with open(self.aliases_path, "w", encoding="utf-8") as f:
+            json.dump(aliases, f, indent=2, ensure_ascii=False)
+
+    def _parse_identifier(self, identifier: str) -> Dict[str, Optional[str]]:
+        """Parse HuggingFace-style identifier.
+
+        Format: namespace/name[@subset][@version]
+
+        Returns:
+            Dict with keys: namespace, name, subset, version
+        """
+        # Check if it's a UUID
+        if self._is_uuid(identifier):
+            return {
+                "uuid": identifier,
+                "namespace": None,
+                "name": None,
+                "subset": None,
+                "version": None
+            }
+
+        # Parse namespace/name[@subset][@version]
+        pattern = r'^([^/]+)/([^@]+)(?:@([^@]+))?(?:@v?(\d+))?$'
+        match = re.match(pattern, identifier)
+
+        if not match:
+            # If it doesn't match the pattern and is not a UUID,
+            # treat it as a potential UUID for backward compatibility
+            # This handles cases like "nonexistent-uuid" which might be
+            # a malformed UUID that we still want to look up
+            return {
+                "uuid": identifier,
+                "namespace": None,
+                "name": None,
+                "subset": None,
+                "version": None
+            }
+
+        namespace, name, subset_or_version, version = match.groups()
+
+        # Determine if the third group is a subset or version
+        subset = None
+        if subset_or_version:
+            if subset_or_version.startswith('v') or subset_or_version.isdigit():
+                version = subset_or_version.lstrip('v')
+                subset = None
+            else:
+                subset = subset_or_version
+
+        return {
+            "uuid": None,
+            "namespace": namespace,
+            "name": name,
+            "subset": subset,
+            "version": int(version) if version else None
+        }
+
+    def _is_uuid(self, value: str) -> bool:
+        """Check if a string is a valid UUID."""
+        try:
+            uuid.UUID(value)
+            return True
+        except (ValueError, AttributeError):
+            return False
+
+    def _get_prompt_path(
+        self,
+        namespace: str,
+        name: str,
+        subset: Optional[str] = None,
+        version: Optional[int] = None
+    ) -> Path:
+        """Get the file path for a prompt.
+
+        Args:
+            namespace: The namespace
+            name: The prompt name
+            subset: Optional subset
+            version: Optional version number
+
+        Returns:
+            Path to the prompt file
+        """
+        prompt_dir = self.location / namespace / name
+
+        if subset:
+            if version:
+                return prompt_dir / "subsets" / f"{subset}_v{version}.md"
+            else:
+                return prompt_dir / "subsets" / f"{subset}.md"
+        elif version:
+            return prompt_dir / "versions" / f"v{version}.md"
+        else:
+            return prompt_dir / "prompt.md"
+
+    def _read_prompt_file(self, file_path: Path) -> Prompt:
+        """Read a prompt from a markdown file."""
+        if not file_path.exists():
+            raise PromptNotFoundError(f"Prompt file not found: {file_path}")
+
+        with open(file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        return Prompt.from_markdown(content)
+
+    def _write_prompt_file(self, file_path: Path, prompt: Prompt):
+        """Write a prompt to a markdown file."""
+        if self.readonly:
+            raise ReadOnlyStoreError("Cannot modify a read-only prompt store")
+
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(file_path, "w", encoding="utf-8") as f:
+            f.write(prompt.to_markdown())
+
     @classmethod
     def from_dict(cls, prompts: Dict, readonly: bool = True) -> "PromptStore":
         """Create a PromptStore from a dictionary.
 
         Args:
-            prompts: Dictionary of prompt data
+            prompts: Dictionary of prompt data (old JSON format)
             readonly: If True, the store will be read-only
 
         Returns:
@@ -58,11 +190,47 @@ class PromptStore:
         import tempfile
 
         temp_dir = Path(tempfile.mkdtemp())
-        store = cls(temp_dir, readonly=readonly)
+        # Create store as writable first to populate it
+        store = cls(temp_dir, readonly=False)
 
-        with open(store.index_path, "w", encoding="utf-8") as f:
-            json.dump(prompts, f, indent=2, ensure_ascii=False)
+        # Convert old format to new format
+        for uuid_val, data in prompts.items():
+            # Create a prompt with the old data
+            namespace = data.get("namespace", "default")
+            name = data.get("name", f"prompt-{uuid_val[:8]}")
 
+            prompt = Prompt(
+                uuid=uuid_val,
+                name=name,
+                namespace=namespace,
+                content=data["content"],
+                description=data.get("description"),
+                version=data.get("version", 1),
+                tags=data.get("tags", []),
+                created_at=data.get("created_at"),
+                updated_at=data.get("updated_at"),
+            )
+
+            # Save to file system
+            file_path = store._get_prompt_path(namespace, name)
+            store._write_prompt_file(file_path, prompt)
+
+            # Update index
+            index = store._load_index()
+            index[uuid_val] = {
+                "namespace": namespace,
+                "name": name,
+                "path": str(file_path.relative_to(store.location))
+            }
+            store._save_index(index)
+
+            # Update aliases
+            aliases = store._load_aliases()
+            aliases[f"{namespace}/{name}"] = uuid_val
+            store._save_aliases(aliases)
+
+        # Now set to readonly if requested
+        store.readonly = readonly
         return store
 
     @classmethod
@@ -81,31 +249,32 @@ class PromptStore:
             raise FileNotFoundError(f"Prompt file not found: {path}")
 
         if path.is_file():
-            # If it's a single JSON file
+            # If it's a single JSON file (old format)
             with open(path, "r", encoding="utf-8") as f:
                 prompts = json.load(f)
+            return cls.from_dict(prompts, readonly=readonly)
         else:
-            # If it's a directory containing an index.json
-            index_path = path / "index.json"
-            if not index_path.exists():
-                raise FileNotFoundError(f"No index.json found in directory: {path}")
-            with open(index_path, "r", encoding="utf-8") as f:
-                prompts = json.load(f)
-
-        return cls.from_dict(prompts, readonly=readonly)
+            # If it's a directory, just use it as the location
+            return cls(path, readonly=readonly)
 
     def add(
         self,
         content: str,
+        name: Optional[str] = None,
+        namespace: Optional[str] = None,
         description: Optional[str] = None,
         tags: Optional[List[str]] = None,
+        subset: Optional[str] = None,
     ) -> Prompt:
         """Add a new prompt to the store.
 
         Args:
             content: The content of the prompt
+            name: Name of the prompt (required for new system)
+            namespace: Namespace/organization (defaults to 'default')
             description: A description of the prompt
             tags: A list of tags for the prompt
+            subset: Optional subset/variant name
 
         Returns:
             Prompt: The newly created prompt
@@ -113,80 +282,102 @@ class PromptStore:
         if self.readonly:
             raise ReadOnlyStoreError("Cannot modify a read-only prompt store")
 
+        # Set defaults
+        if not namespace:
+            namespace = "default"
+        if not name:
+            name = f"prompt-{str(uuid.uuid4())[:8]}"
+
         prompt_uuid = str(uuid.uuid4())
-        now = datetime.utcnow().isoformat()
+        now = datetime.now(timezone.utc).isoformat()
 
-        prompt_data = {
-            "uuid": prompt_uuid,
-            "content": content,
-            "description": description,
-            "version": 1,
-            "versions": [
-                {
-                    "content": content,
-                    "description": description,
-                    "version": 1,
-                    "created_at": now,
-                }
-            ],
-            "tags": tags or [],
-            "created_at": now,
-            "updated_at": now,
-        }
-
-        index = self._load_index()
-        index[prompt_uuid] = prompt_data
-        self._save_index(index)
-
-        return Prompt(
+        prompt = Prompt(
             uuid=prompt_uuid,
+            name=name,
+            namespace=namespace,
             content=content,
             description=description,
             version=1,
             tags=tags or [],
-            timestamp=now,
+            subset=subset,
+            created_at=now,
+            updated_at=now,
         )
 
-    def get(self, uuid: str, version: Optional[int] = None) -> Prompt:
-        """Retrieve a prompt by its UUID.
+        # Save to file system
+        file_path = self._get_prompt_path(namespace, name, subset)
+        self._write_prompt_file(file_path, prompt)
+
+        # Update index
+        index = self._load_index()
+        index[prompt_uuid] = {
+            "namespace": namespace,
+            "name": name,
+            "subset": subset,
+            "path": str(file_path.relative_to(self.location))
+        }
+        self._save_index(index)
+
+        # Update aliases
+        aliases = self._load_aliases()
+        identifier = f"{namespace}/{name}"
+        if subset:
+            identifier += f"@{subset}"
+        aliases[identifier] = prompt_uuid
+        self._save_aliases(aliases)
+
+        return prompt
+
+    def get(
+        self,
+        identifier: str,
+        version: Optional[int] = None,
+        subset: Optional[str] = None
+    ) -> Prompt:
+        """Retrieve a prompt by its identifier or UUID.
 
         Args:
-            uuid: The UUID of the prompt to retrieve
+            identifier: HuggingFace-style identifier or UUID
             version: The version of the prompt to retrieve
+            subset: The subset of the prompt to retrieve
 
         Returns:
             Prompt: The prompt object
         """
-        index = self._load_index()
-        if uuid not in index:
-            raise PromptNotFoundError(f"Prompt with UUID {uuid} not found")
+        parsed = self._parse_identifier(identifier)
 
-        prompt_data = index[uuid]
-
-        if version:
-            version_data = next(
-                (v for v in prompt_data["versions"] if v["version"] == version), None
+        # Handle UUID lookup (backward compatibility)
+        if parsed["uuid"]:
+            warnings.warn(
+                "UUID-based lookup is deprecated. Use 'namespace/name' format.",
+                DeprecationWarning,
+                stacklevel=2
             )
-            if not version_data:
-                raise PromptNotFoundError(
-                    f"Version {version} of prompt {uuid} not found"
-                )
-            content = version_data["content"]
-            description = version_data["description"]
-            timestamp = version_data["created_at"]
-        else:
-            content = prompt_data["content"]
-            description = prompt_data["description"]
-            timestamp = prompt_data["updated_at"]
+            return self._get_by_uuid(parsed["uuid"], version)
 
-        return Prompt(
-            uuid=uuid,
-            content=content,
-            description=description,
-            version=prompt_data["version"],
-            tags=prompt_data["tags"],
-            timestamp=timestamp,
-        )
+        # Use parsed values, but allow override by parameters
+        namespace = parsed["namespace"]
+        name = parsed["name"]
+        subset = subset or parsed["subset"]
+        version = version or parsed["version"]
+
+        # Get the file path and read the prompt
+        file_path = self._get_prompt_path(namespace, name, subset, version)
+        return self._read_prompt_file(file_path)
+
+    def _get_by_uuid(self, uuid_val: str, version: Optional[int] = None) -> Prompt:
+        """Get a prompt by UUID (backward compatibility)."""
+        index = self._load_index()
+        if uuid_val not in index:
+            raise PromptNotFoundError(f"Prompt with UUID {uuid_val} not found")
+
+        entry = index[uuid_val]
+        namespace = entry["namespace"]
+        name = entry["name"]
+        subset = entry.get("subset")
+
+        file_path = self._get_prompt_path(namespace, name, subset, version)
+        return self._read_prompt_file(file_path)
 
     def find(self, query: str, field: str = "description") -> List[Prompt]:
         """Search for prompts based on a query.
@@ -201,38 +392,92 @@ class PromptStore:
         if field not in ("description", "content", "tags"):
             raise ValueError("Field must be 'description', 'content', or 'tags'")
 
-        index = self._load_index()
         prompts = []
-
-        for uuid_, data in index.items():
+        for prompt in self:
             if field == "tags":
-                if any(query.lower() in tag.lower() for tag in data["tags"]):
-                    prompts.append(self._data_to_prompt(uuid_, data))
-            else:
-                value = data.get(field, "")
-                if value and query.lower() in value.lower():
-                    prompts.append(self._data_to_prompt(uuid_, data))
+                if any(query.lower() in tag.lower() for tag in prompt.tags):
+                    prompts.append(prompt)
+            elif field == "description" and prompt.description:
+                if query.lower() in prompt.description.lower():
+                    prompts.append(prompt)
+            elif field == "content":
+                if query.lower() in prompt.content.lower():
+                    prompts.append(prompt)
 
         return prompts
 
-    def _data_to_prompt(self, uuid: str, data: Dict) -> Prompt:
-        """Convert raw data to a Prompt object.
+    def update(
+        self,
+        identifier: str,
+        content: str,
+        description: Optional[str] = None,
+        tags: Optional[List[str]] = None,
+    ) -> Prompt:
+        """Update an existing prompt with a new version.
 
         Args:
-            uuid: The UUID of the prompt
-            data: The raw data for the prompt
+            identifier: The identifier or UUID of the prompt to update
+            content: New content for the prompt
+            description: New description for the prompt
+            tags: New tags for the prompt
 
         Returns:
-            Prompt: The prompt object
+            Prompt: The updated prompt
+
+        Raises:
+            ReadOnlyStoreError: If the store is read-only
+            PromptNotFoundError: If the prompt doesn't exist
         """
-        return Prompt(
-            uuid=uuid,
-            content=data["content"],
-            description=data["description"],
-            version=data["version"],
-            tags=data["tags"],
-            timestamp=data["updated_at"],
+        if self.readonly:
+            raise ReadOnlyStoreError("Cannot modify a read-only prompt store")
+
+        # Get the current prompt
+        current = self.get(identifier)
+
+        # Create new version
+        now = datetime.now(timezone.utc).isoformat()
+        new_version = current.version + 1
+
+        # Save old version to versions directory if it's not already there
+        if current.version > 0:
+            old_version_path = self._get_prompt_path(
+                current.namespace, current.name, current.subset, current.version
+            )
+            if not old_version_path.exists():
+                self._write_prompt_file(old_version_path, current)
+
+        # Create updated prompt
+        updated = Prompt(
+            uuid=current.uuid,
+            name=current.name,
+            namespace=current.namespace,
+            content=content,
+            description=description if description is not None else current.description,
+            version=new_version,
+            tags=tags if tags is not None else current.tags,
+            subset=current.subset,
+            created_at=current.created_at,
+            updated_at=now,
         )
+
+        # Write new version as the main prompt
+        file_path = self._get_prompt_path(
+            current.namespace, current.name, current.subset
+        )
+        self._write_prompt_file(file_path, updated)
+
+        return updated
+
+    def __iter__(self) -> Iterator[Prompt]:
+        """Iterate over all prompts in the store."""
+        index = self._load_index()
+        for _, entry in index.items():
+            try:
+                file_path = self.location / entry["path"]
+                yield self._read_prompt_file(file_path)
+            except Exception:
+                # Skip prompts that can't be read
+                continue
 
     def merge(self, other: "PromptStore", override: bool = False):
         """Merge another PromptStore into this one.
@@ -247,86 +492,30 @@ class PromptStore:
         if self.readonly:
             raise ReadOnlyStoreError("Cannot modify a read-only prompt store")
 
-        our_index = self._load_index()
-        their_index = other._load_index()
+        for prompt in other:
+            identifier = f"{prompt.namespace}/{prompt.name}"
+            if prompt.subset:
+                identifier += f"@{prompt.subset}"
 
-        for uuid_, their_data in their_index.items():
-            if uuid not in our_index or override:
-                our_index[uuid_] = their_data
-
-        self._save_index(our_index)
-
-    def __iter__(self) -> Iterator[Prompt]:
-        """Iterate over all prompts in the store."""
-        index = self._load_index()
-        for uuid_, data in index.items():
-            yield self._data_to_prompt(uuid_, data)
-
-    def update(
-        self,
-        uuid: str,
-        content: str,
-        description: Optional[str] = None,
-        tags: Optional[List[str]] = None,
-    ) -> Prompt:
-        """Update an existing prompt with a new version.
-
-        Args:
-            uuid: The UUID of the prompt to update
-            content: New content for the prompt
-            description: New description for the prompt
-            tags: New tags for the prompt
-
-        Returns:
-            Prompt: The updated prompt
-
-        Raises:
-            ReadOnlyStoreError: If the store is read-only
-            PromptNotFoundError: If the prompt with the given UUID doesn't exist
-        """
-        if self.readonly:
-            raise ReadOnlyStoreError("Cannot modify a read-only prompt store")
-
-        index = self._load_index()
-        if uuid not in index:
-            raise PromptNotFoundError(f"Prompt with UUID {uuid} not found")
-
-        prompt_data = index[uuid]
-        now = datetime.utcnow().isoformat()
-
-        new_version = prompt_data["version"] + 1
-
-        prompt_data["versions"].append(
-            {
-                "content": content,
-                "description": description
-                if description is not None
-                else prompt_data["description"],
-                "version": new_version,
-                "created_at": now,
-            }
-        )
-
-        prompt_data["content"] = content
-        if description is not None:
-            prompt_data["description"] = description
-        if tags is not None:
-            prompt_data["tags"] = tags
-        prompt_data["version"] = new_version
-        prompt_data["updated_at"] = now
-
-        self._save_index(index)
-
-        return Prompt(
-            uuid=uuid,
-            content=content,
-            description=description
-            if description is not None
-            else prompt_data["description"],
-            version=new_version,
-            tags=tags if tags is not None else prompt_data["tags"],
-            timestamp=now,
-        )
+            try:
+                self.get(identifier)
+                if override:
+                    self.update(
+                        identifier,
+                        content=prompt.content,
+                        description=prompt.description,
+                        tags=prompt.tags,
+                    )
+            except PromptNotFoundError:
+                # Doesn't exist, add it
+                self.add(
+                    content=prompt.content,
+                    name=prompt.name,
+                    namespace=prompt.namespace,
+                    description=prompt.description,
+                    tags=prompt.tags,
+                    subset=prompt.subset,
+                )
 
     def get_online(
         self, uuid: str, url: str, version: int | None = None, folder: str = "prompts"

--- a/src/promptstore/store.py
+++ b/src/promptstore/store.py
@@ -4,10 +4,10 @@ import uuid
 import warnings
 from datetime import datetime, timezone
 from pathlib import Path
-from loguru import logger
 from typing import Dict, Iterator, List, Optional, Union
 
 import pystow
+from loguru import logger
 
 from promptstore.exceptions import PromptNotFoundError, ReadOnlyStoreError
 from promptstore.prompt import Prompt

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -47,3 +47,59 @@ def test_prompt_attributes():
     assert prompt.version == 1
     assert prompt.tags == tags
     assert prompt.timestamp == "2024-02-11T10:00:00"
+
+
+def test_markdown_variable_highlighting():
+    """Test that variables are highlighted in markdown export and
+    unhighlighted on import."""
+    # Create a prompt with variables
+    prompt = Prompt(
+        uuid="test-uuid",
+        name="test-prompt",
+        namespace="test",
+        content="Write a {{language}} function that {{task}}",
+        version=1,
+        description="Test prompt",
+    )
+
+    # Export to markdown - variables should be highlighted
+    markdown = prompt.to_markdown()
+    assert "**`{{language}}`**" in markdown
+    assert "**`{{task}}`**" in markdown
+
+    # Import from markdown - variables should be unhighlighted
+    loaded_prompt = Prompt.from_markdown(markdown)
+    assert loaded_prompt.content == "Write a {{language}} function that {{task}}"
+    assert loaded_prompt.variables == ["language", "task"]
+
+    # Verify it still works for filling
+    filled = loaded_prompt.fill({"language": "Python", "task": "sorts a list"})
+    assert filled == "Write a Python function that sorts a list"
+
+
+def test_markdown_roundtrip_with_highlighting():
+    """Test that prompts can be exported and imported without data loss."""
+    original = Prompt(
+        uuid="test-uuid",
+        name="test-prompt",
+        namespace="test",
+        content="Hello {{name}}, your task is {{task}}!",
+        version=1,
+        description="Test prompt",
+        tags=["test", "demo"],
+    )
+
+    # Export and re-import
+    markdown = original.to_markdown()
+    loaded = Prompt.from_markdown(markdown)
+
+    # Verify all data is preserved
+    assert loaded.uuid == original.uuid
+    assert loaded.name == original.name
+    assert loaded.namespace == original.namespace
+    assert loaded.content == original.content
+    assert loaded.version == original.version
+    assert loaded.description == original.description
+    assert loaded.tags == original.tags
+    assert loaded.variables == original.variables
+

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -102,4 +102,3 @@ def test_markdown_roundtrip_with_highlighting():
     assert loaded.description == original.description
     assert loaded.tags == original.tags
     assert loaded.variables == original.variables
-

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -108,3 +108,143 @@ def test_from_dict():
     assert prompt.content == "test content"
     assert prompt.description == "test description"
     assert prompt.tags == ["test"]
+
+
+def test_add_with_namespace_and_name(store):
+    """Test adding a prompt with explicit namespace and name."""
+    prompt = store.add(
+        content="test content",
+        name="my-prompt",
+        namespace="myorg",
+        description="test description",
+    )
+
+    assert prompt.name == "my-prompt"
+    assert prompt.namespace == "myorg"
+    assert prompt.identifier == "myorg/my-prompt"
+
+
+def test_get_by_identifier(store):
+    """Test retrieving a prompt using HuggingFace-style identifier."""
+    added = store.add(
+        content="test content",
+        name="my-prompt",
+        namespace="myorg",
+        description="test description",
+    )
+
+    # Retrieve by identifier
+    retrieved = store.get("myorg/my-prompt")
+    assert retrieved.uuid == added.uuid
+    assert retrieved.content == added.content
+    assert retrieved.name == "my-prompt"
+    assert retrieved.namespace == "myorg"
+
+
+def test_add_with_subset(store):
+    """Test adding a prompt with a subset."""
+    prompt = store.add(
+        content="test content for python",
+        name="code-gen",
+        namespace="myorg",
+        subset="python",
+        description="Python code generator",
+    )
+
+    assert prompt.subset == "python"
+    assert prompt.identifier == "myorg/code-gen@python"
+
+
+def test_get_by_identifier_with_subset(store):
+    """Test retrieving a prompt with subset using identifier."""
+    added = store.add(
+        content="test content for python",
+        name="code-gen",
+        namespace="myorg",
+        subset="python",
+        description="Python code generator",
+    )
+
+    # Retrieve by identifier with subset
+    retrieved = store.get("myorg/code-gen@python")
+    assert retrieved.uuid == added.uuid
+    assert retrieved.subset == "python"
+
+
+def test_update_creates_version(store):
+    """Test that updating a prompt creates a new version."""
+    added = store.add(
+        content="original content",
+        name="my-prompt",
+        namespace="myorg",
+        description="original description",
+    )
+
+    assert added.version == 1
+
+    # Update the prompt
+    updated = store.update(
+        "myorg/my-prompt",
+        content="updated content",
+        description="updated description",
+    )
+
+    assert updated.version == 2
+    assert updated.content == "updated content"
+    assert updated.description == "updated description"
+    assert updated.uuid == added.uuid  # Same UUID
+
+
+def test_markdown_persistence(store):
+    """Test that prompts are persisted as markdown files."""
+    added = store.add(
+        content="test content",
+        name="my-prompt",
+        namespace="myorg",
+        description="test description",
+        tags=["test", "example"],
+    )
+
+    # Check that the markdown file exists
+    prompt_path = store.location / "myorg" / "my-prompt" / "prompt.md"
+    assert prompt_path.exists()
+
+    # Read the file and verify it's markdown with frontmatter
+    with open(prompt_path, "r") as f:
+        content = f.read()
+
+    assert content.startswith("---")
+    assert "name: my-prompt" in content
+    assert "namespace: myorg" in content
+    assert "test content" in content
+    assert added.uuid in content  # UUID should be in frontmatter
+
+
+def test_to_markdown_and_from_markdown(store):
+    """Test that prompts can be serialized and deserialized to/from markdown."""
+    from promptstore.prompt import Prompt
+
+    # Create a prompt
+    original = Prompt(
+        name="test-prompt",
+        namespace="test",
+        content="test content with {{variable}}",
+        description="test description",
+        version=1,
+        tags=["tag1", "tag2"],
+    )
+
+    # Convert to markdown
+    markdown = original.to_markdown()
+
+    # Convert back from markdown
+    restored = Prompt.from_markdown(markdown)
+
+    assert restored.name == original.name
+    assert restored.namespace == original.namespace
+    assert restored.content == original.content
+    assert restored.description == original.description
+    assert restored.version == original.version
+    assert restored.tags == original.tags
+    assert restored.uuid == original.uuid
+

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -247,4 +247,3 @@ def test_to_markdown_and_from_markdown(store):
     assert restored.version == original.version
     assert restored.tags == original.tags
     assert restored.uuid == original.uuid
-


### PR DESCRIPTION
## Summary by Sourcery

Migrate PromptStore to a file-based system, storing prompts as individual markdown files with YAML frontmatter, introduce namespace/subset/version identifiers and alias mapping, and maintain backward compatibility with existing JSON formats while highlighting template variables in exports

New Features:
- Save prompts as markdown files with YAML frontmatter and highlight Jinja2 variables for readability
- Organize prompts in a file-based structure under a .promptstore directory with separate index.json and aliases.json
- Support namespace/name[@subset][@version] identifiers with alias mapping and deprecation warning for legacy UUID lookups
- Store subsets and versioned prompt files in dedicated subdirectories
- Provide backward compatibility loaders from old JSON stores via from_dict and from_file

Enhancements:
- Refactor add, get, update, find, merge, and iteration methods to operate on the filesystem instead of in-memory JSON
- Restructure storage layout to derive prompt paths and manage aliases and index through file operations

Documentation:
- Document markdown export/import with variable highlighting and update usage examples for namespace, subsets, and file-based workflow

Tests:
- Add tests for namespace/name/subset identifier handling, versioning behavior, markdown persistence, and variable highlighting round-trip