### PR TITLE
feat: add action for automatic publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Publish to PyPI
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  build-and-publish:
+    # Only run if the PR was actually merged (not just closed)
+    if: github.event.pull_request.merged == true
+
+    runs-on: ubuntu-latest
+
+    # Needed for OIDC / Trusted Publishing
+    permissions:
+      id-token: write
+      contents: read
+
+    # Must match the environment you configure on PyPI for Trusted Publishing
+    environment:
+      name: pypi
+      url: https://pypi.org/p/promptstore  # adjust if the project name changes
+    # version configured in the environment must match the version in pyproject.toml
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build distribution
+        run: python -m build  # creates dist/*.whl and dist/*.tar.gz
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
 name = "promptstore"
+version = "0.1.0"
 authors = [{ email = "hello@lamalab.org", name = "lamalab group members" }]
 description = "A lightweight package for managing and versioning LLM prompt templates"
 readme = "README.md"
@@ -20,7 +21,6 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dependencies = ["jinja2>=3.0.0", "pystow>=0.7.0"]
-dynamic = ["version"]
 license = { file = "LICENSE" }
 
 [project.optional-dependencies]
@@ -36,9 +36,6 @@ dev = [
 
 [project.urls]
 repository = "https://github.com/lamalab-org/promptstore"
-
-[tool.hatch]
-version.source = "vcs"
 
 [tool.hatch.build]
 packages = ["src/promptstore"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python",
 ]
-dependencies = ["jinja2>=3.0.0", "pystow>=0.7.0"]
+dependencies = ["jinja2>=3.0.0", "pystow>=0.7.0", "loguru"]
 license = { file = "LICENSE" }
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary by Sourcery

Add a CI workflow for automatic PyPI publishing and simplify version management in pyproject.toml

New Features:
- Add GitHub Action to automatically publish the package to PyPI on merged pull requests

Enhancements:
- Pin project version to 0.1.0 in pyproject.toml and remove dynamic versioning and hatch-vcs dependency

CI:
- Introduce release.yml workflow to build artifacts and publish to PyPI using OIDC-trusted publishing